### PR TITLE
Add general categories

### DIFF
--- a/src/lib/components/Nav.svelte
+++ b/src/lib/components/Nav.svelte
@@ -30,6 +30,7 @@
 		<hr />
 		<h2>Browse</h2>
 		<NavLink {segment} {closeMenu} href="/blocks">Blocks</NavLink>
+		<NavLink {segment} {closeMenu} href="/categories">Categories</NavLink>
 		<NavLink {segment} {closeMenu} href="/sequences">Sequences</NavLink>
 		<NavLink {segment} {closeMenu} href="/versions">Versions</NavLink>
 	</ul>

--- a/src/lib/server/Unicode.ts
+++ b/src/lib/server/Unicode.ts
@@ -752,3 +752,73 @@ export function getEmoji(): Char[] {
 	cachedEmoji = list;
 	return list;
 }
+
+export interface GeneralCategory {
+	abbr: string,
+	name: string,
+	slug: string,
+	count: number,
+}
+
+const categories: GeneralCategory[] = [];
+const categoriesByAbbr: Map<string, GeneralCategory> = new Map();
+for (const entry of Data.valueAliases) {
+	if (entry.Type != 'gc') continue;
+	// the 1-letter abbrevs are categories-of-categories
+	if (entry.Value.length == 1) continue;
+
+	const category = {
+		abbr: entry.Value,
+		name: entry.Alias.replace('_', ' '),
+		slug: toSlug(entry.Alias),
+		count: 0,
+	};
+	categories.push(category);
+	categoriesByAbbr.set(entry.Value, category);
+	aliasValues.set(entry.Type + ":" + entry.Value, entry.Alias)
+}
+categories.sort((a, b) => {
+	if (a.abbr < b.abbr) return -1;
+	if (a.abbr > b.abbr) return 1;
+	return 0;
+});
+
+for (const entry of charList) {
+	const category = categoriesByAbbr.get(entry.General_Category);
+	if (entry.range)
+		category.count += entry.range.last - entry.range.first + 1;
+	else
+		category.count += 1;
+}
+
+export function getCategories(): GeneralCategory[] {
+	return categories;
+}
+
+const cachedCategoryCodepoints: Map<string, Char[]> = new Map();
+export function getCodepointsInCategory(abbr: string): Char[] {
+	if (cachedCategoryCodepoints.has(abbr))
+		return cachedCategoryCodepoints.get(abbr);
+
+	const list = [];
+	const limit = 1000;
+	for (const entry of charList) {
+		if (list.length >= limit) break;
+		if (entry.General_Category != abbr) continue;
+		if (entry.Codepoint != null) {
+			const char = parseEntry(entry, entry.Codepoint);
+			list.push(char);
+		} else {
+			const start = entry.range.first;
+			const stop = Math.min(entry.range.last, start + limit - list.length - 1);
+			for (let i = start; i <= stop; i++) {
+				const char = parseEntry(entry, i);
+				list.push(char);
+			}
+		}
+	}
+
+	cachedCategoryCodepoints.set(abbr, list);
+
+	return list;
+}

--- a/src/routes/categories/+page.svelte
+++ b/src/routes/categories/+page.svelte
@@ -1,0 +1,29 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+ !-- License, v. 2.0. If a copy of the MPL was not distributed with this
+ !-- file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<script lang="ts">
+	import OpenGraph from "$lib/components/OpenGraph.svelte";
+	import type { PageData } from "./$types";
+
+	export let data: PageData;
+</script>
+
+<OpenGraph title="Blocks" description="Browse the categories in Unicode." />
+
+<h1>Categories</h1>
+
+<ul>
+	{#each data.categories as category}
+		<li>
+			<a href="/categories/{category.slug}">
+				({category.abbr}) {category.name}
+			</a>
+		</li>
+	{/each}
+</ul>
+
+<style>
+a {
+	text-decoration: none;
+}
+</style>

--- a/src/routes/categories/+page.ts
+++ b/src/routes/categories/+page.ts
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { error } from "@sveltejs/kit";
+import type { PageLoad } from "./$types";
+
+export const load: PageLoad = async ({ fetch }) => {
+	const response: Response = await fetch("/categories/list.json");
+	if (response.status == 200) {
+		const blocks = await response.json();
+		return blocks;
+	} else {
+		error(404, "Couldn't load list of blocks");
+	}
+};

--- a/src/routes/categories/[slug]/+page.svelte
+++ b/src/routes/categories/[slug]/+page.svelte
@@ -1,0 +1,62 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+ !-- License, v. 2.0. If a copy of the MPL was not distributed with this
+ !-- file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<script lang="ts">
+	import { getDisplayText } from "$lib/strings";
+	import OpenGraph from "$lib/components/OpenGraph.svelte";
+	import type { PageData } from "./$types";
+	import type { Char } from "$lib/server/Unicode";
+
+	export let data: PageData;
+</script>
+
+<OpenGraph
+	title="{data.category.name} - Categories"
+	description="View codepoints in the {data.category.name} Unicode category."
+/>
+
+<h1>{data.category.name} ({data.category.abbr})</h1>
+
+<p>This category contains {data.category.count} codepoints.</p>
+
+{#if data.category.codepoints.length < data.category.count}
+	<p>Only the first {data.category.codepoints.length} are shown here.</p>
+{/if}
+
+<div class="table">
+	{#each data.category.codepoints as char}
+		{#if char.type == "char"}
+			<a href="/codepoint/{char.slug}" rel="nofollow">
+				<div class="char"><span>{char.text}</span></div>
+				<div><code>U+{char.codepointStr}</code></div>
+				<div><span>{char.name}</span></div>
+			</a>
+		{:else}
+			<a href="/codepoint/{char.slug}" rel="nofollow">
+				<div>N/A</div>
+				<div><code>0x{char.codepointStr}</code></div>
+				<div>{getDisplayText(char.reason)}</div>
+			</a>
+		{/if}
+	{/each}
+</div>
+
+<style>
+	.table {
+		grid-template-columns: 3em min-content 1fr;
+	}
+
+	.char {
+		font-size: 1.2em;
+		text-align: center;
+	}
+
+	.table a {
+		text-decoration: none;
+	}
+
+	.table a:hover,
+	.table a:focus {
+		text-decoration: underline;
+	}
+</style>

--- a/src/routes/categories/[slug]/+page.ts
+++ b/src/routes/categories/[slug]/+page.ts
@@ -1,0 +1,17 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { error } from "@sveltejs/kit";
+import type { PageLoad } from "./$types";
+
+export const load: PageLoad = async ({ params, fetch }) => {
+	const { slug } = params;
+	const response: Response = await fetch(`/categories/${slug}/data.json`);
+	if (response.status == 200) {
+		const category = await response.json();
+		return { category };
+	} else {
+		error(404, `Could not find any Unicode category named ${slug}.`);
+	}
+};

--- a/src/routes/categories/[slug]/data.json/+server.ts
+++ b/src/routes/categories/[slug]/data.json/+server.ts
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import {
+	getCategories,
+	getCodepointsInCategory,
+} from "$lib/server/Unicode";
+import { error, json, type RequestHandler } from "@sveltejs/kit";
+
+export const GET = (async ({ params }) => {
+	const { slug } = params;
+
+	const categories = getCategories();
+	const category = categories.find((cat) => cat.slug == slug);
+	if (!category) {
+		error(404);
+	}
+
+	const codepoints = getCodepointsInCategory(category.abbr);
+
+	return json({
+		...category,
+		codepoints,
+	});
+}) satisfies RequestHandler;

--- a/src/routes/categories/list.json/+server.ts
+++ b/src/routes/categories/list.json/+server.ts
@@ -1,0 +1,12 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { getCategories } from "$lib/server/Unicode";
+import { json, type RequestHandler } from "@sveltejs/kit";
+
+export const GET = (async ({ url }) => {
+	return json({
+		categories: getCategories(),
+	});
+}) satisfies RequestHandler;


### PR DESCRIPTION
Adds the new pages:

- `/categories` with a list of the available categories
- `/categories/[slug]` for each category, with a list of codepoints